### PR TITLE
Style: Change "Position", "Company", & "Location" Format

### DIFF
--- a/GreenhouseParse.java
+++ b/GreenhouseParse.java
@@ -12,6 +12,7 @@ public class GreenhouseParse extends HTMLEditorKit.ParserCallback {
     private boolean isValidGroupTag = false;
     private boolean isValidApplyNowButtonTag = false;
     private boolean isValidPositionTitleTag = false;
+    private boolean isValidCompanyNameTag = false;
     private boolean isValidPositionLocationTag = false;
 
     /**
@@ -59,12 +60,38 @@ public class GreenhouseParse extends HTMLEditorKit.ParserCallback {
 
     private void formatPositionTitle(char[] data) {
         String title = new String(data);
-        System.out.print("" + title + " ");
+        System.out.println("Position:\t" + title + " ");
     }
 
     /**
      * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-     * ------------------ Methods To Handle Position Location ---------------- *
+     * ------------------- Methods To Handle Company Title ------------------- *
+     * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+     */
+
+    private boolean isValidCompanyNameStartTag(HTML.Tag tag, MutableAttributeSet mas) {
+        boolean isValidCompanyNameTag = false;
+        if (tag.equals(HTML.Tag.SPAN) && mas.containsAttribute(HTML.Attribute.CLASS, "company-name")) {
+            isValidCompanyNameTag = true;
+        }
+        return isValidCompanyNameTag;
+    }
+
+    private boolean isValidCompanyNameEndTag(HTML.Tag tag) {
+        return tag.equals(HTML.Tag.SPAN);
+    }
+
+    private void formatCompanyName(char[] data) {
+        char[] companyName = new char[data.length - 3];
+        for (int i = 3; i < data.length; i++) {
+            companyName[i - 3] = data[i];
+        }
+        System.out.println("Company:\t" + new String(companyName));
+    }
+
+    /**
+     * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+     * ----------------- Methods To Handle Position Location ----------------- *
      * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
      */
 
@@ -82,7 +109,7 @@ public class GreenhouseParse extends HTMLEditorKit.ParserCallback {
 
     private void formatPositionLocation(char[] data) {
         String location = new String(data);
-        System.out.println("Location: " + location);
+        System.out.println("Location:\t" + location + "\n");
     }
 
     /**
@@ -136,6 +163,9 @@ public class GreenhouseParse extends HTMLEditorKit.ParserCallback {
         if (isValidPositionTitleStartTag(tag, mas)) {
             isValidPositionTitleTag = true;
         }
+        if (isValidCompanyNameStartTag(tag, mas)) {
+            isValidCompanyNameTag = true;
+        }
         if (isValidPositionLocationStartTag(tag, mas)) {
             isValidPositionLocationTag = true;
         }
@@ -154,6 +184,9 @@ public class GreenhouseParse extends HTMLEditorKit.ParserCallback {
         if (isValidPositionTitleEndTag(tag)) {
             isValidPositionTitleTag = false;
         }
+        if (isValidCompanyNameEndTag(tag)) {
+            isValidCompanyNameTag = false;
+        }
         if (isValidPositionLocationEndTag(tag)) {
             isValidPositionLocationTag = false;
         }
@@ -168,6 +201,8 @@ public class GreenhouseParse extends HTMLEditorKit.ParserCallback {
                 formatApplyNowButton(data);
             } else if (isValidPositionTitleTag) {
                 formatPositionTitle(data);
+            } else if (isValidCompanyNameTag) {
+                formatCompanyName(data);
             } else if (isValidPositionLocationTag) {
                 formatPositionLocation(data);
             } else {


### PR DESCRIPTION
**Before The PR (Pull Request):**
The resulting "print" statement in the Terminal when the program was officially run would show the following as the format of the first two lines of text:
```
<Position> at <Company Name>
Location: <Geographic Location of Role as Listed in Parsed Job Description>
```

**After The PR (Pull Request):**
The resulting "print" statement in the Terminal when the program is officially run shows the following as the format of the first three lines of text followed by an empty line:
```
Position: <Position Title>
Company: <Company Name>
Location: <Company Location> 
```
Note: A tab was added for more even spacing between the row "key" and it's respective corresponding value. 

**Why Was This Changed?**
Breaking apart what amounts to be the "header" of the parsed document into separate "heading-demarcated" lines makes it easier for the User to scan the document and reference which role they are reviewing.

**What Was Changed?**
- Added state for "Company Name".
- Amended printing format of `formatPositionTitle()`.
- Added methods to handle "Company Name".
- Amended printing format of `formatPositionLocation()`.
- Added company methods to `handleStartTag()`, `handleEndTag()`, & `handleText()`.
- Update Comment Formatting

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
N/A

**Mentions:** _(Type `@` then the person's name)_
N/A
