### PR TITLE
Feat: Add `<strong>` Tag Support In 'GreenhouseParse' Class

### DIFF
--- a/GreenhouseParse.java
+++ b/GreenhouseParse.java
@@ -18,6 +18,7 @@ public class GreenhouseParse extends HTMLEditorKit.ParserCallback {
     private boolean isValidHTag = false;
     private boolean isValidLITag = false;
     private boolean isValidPTag = false;
+    private boolean isValidSTRONGTag = false;
 
     /**
      * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -239,7 +240,7 @@ public class GreenhouseParse extends HTMLEditorKit.ParserCallback {
 
     /**
      * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-     * ---------------- Methods To Handle Paragraph (p) Tags ----------------- *
+     * ---------------- Methods To Handle Paragraph (P) Tags ----------------- *
      * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
      */
 
@@ -250,6 +251,21 @@ public class GreenhouseParse extends HTMLEditorKit.ParserCallback {
     private void formatPTag(char[] data) {
         String paragraph = new String(data);
         System.out.println("\n" + paragraph);
+    }
+
+    /**
+     * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+     * ---------------- Methods To Handle Strong (STRONG) Tags --------------- *
+     * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+     */
+
+    private boolean isValidSTRONGTag(HTML.Tag tag) {
+        return tag.equals(HTML.Tag.STRONG);
+    }
+
+    private void formatSTRONGTag(char[] data) {
+        String strong = new String(data);
+        System.out.print(" " + strong + " ");
     }
 
     /**
@@ -289,6 +305,9 @@ public class GreenhouseParse extends HTMLEditorKit.ParserCallback {
         if (isValidPTag(tag)) {
             isValidPTag = true;
         }
+        if (isValidSTRONGTag(tag)) {
+            isValidSTRONGTag = true;
+        }
     }
 
     public void handleEndTag(HTML.Tag tag, int pos) {
@@ -322,6 +341,9 @@ public class GreenhouseParse extends HTMLEditorKit.ParserCallback {
         if (isValidPTag(tag)) {
             isValidPTag = false;
         }
+        if (isValidSTRONGTag(tag)) {
+            isValidSTRONGTag = false;
+        }
     }
 
     public void handleText(char[] data, int pos) {
@@ -348,6 +370,8 @@ public class GreenhouseParse extends HTMLEditorKit.ParserCallback {
                 formatLITag(data);
             } else if (isValidPTag) {
                 formatPTag(data);
+            } else if (isValidSTRONGTag) {
+                formatSTRONGTag(data);
             }
         }
     }


### PR DESCRIPTION
**Before The PR (Pull Request):**
There was no "back end" support for the proper parsing of text encapsulated within <strong></strong> resulting in that text being parsed according to the rules related to the tag enveloping the <strong></strong>.

**After The PR (Pull Request):**
There is basic "back end" support for the proper parsing of text encapsulated within <strong></strong>, allowing customization of how those tags can be handled.

**Why Was This Changed?**
Due to some issues with formatting the parsed "Job Description", the addition of the ability to support <strong></strong> within the 'GreenhouseParse' class was made to avoid future issues with document parsing and formatting. 

**What Was Changed?**
- Added class state for <strong> tag parsing support.
- Added methods to handle <strong> tags.
- Added new tag methods to `handle...Tag()`, `handleText()` methods.
- Amended one comment for synchronicity.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Closes #8 

**Mentions:** _(Type `@` then the person's name)_
N/A