### PR TITLE
Feat: Add <a> Tag Support In 'GreenhouseParse' Class

### DIFF
--- a/GreenhouseParse.java
+++ b/GreenhouseParse.java
@@ -19,6 +19,7 @@ public class GreenhouseParse extends HTMLEditorKit.ParserCallback {
     private boolean isValidLITag = false;
     private boolean isValidPTag = false;
     private boolean isValidSTRONGTag = false;
+    private boolean isValidATag = false;
 
     /**
      * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -270,6 +271,21 @@ public class GreenhouseParse extends HTMLEditorKit.ParserCallback {
 
     /**
      * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+     * ---------------- Methods To Handle Strong (STRONG) Tags --------------- *
+     * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+     */
+
+    private boolean isValidATag(HTML.Tag tag) {
+        return tag.equals(HTML.Tag.A);
+    }
+
+    private void formatATag(char[] data) {
+        String a = new String(data);
+        System.out.print(" " + a + " ");
+    }
+
+    /**
+     * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
      * ------- Overridden `HTMLEditorKit.ParserCallback` Class Methods ------- *
      * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
      */
@@ -308,6 +324,9 @@ public class GreenhouseParse extends HTMLEditorKit.ParserCallback {
         if (isValidSTRONGTag(tag)) {
             isValidSTRONGTag = true;
         }
+        if (isValidATag(tag)) {
+            isValidATag = true;
+        }
     }
 
     public void handleEndTag(HTML.Tag tag, int pos) {
@@ -344,6 +363,9 @@ public class GreenhouseParse extends HTMLEditorKit.ParserCallback {
         if (isValidSTRONGTag(tag)) {
             isValidSTRONGTag = false;
         }
+        if (isValidATag(tag)) {
+            isValidATag = false;
+        }
     }
 
     public void handleText(char[] data, int pos) {
@@ -358,7 +380,6 @@ public class GreenhouseParse extends HTMLEditorKit.ParserCallback {
                 formatViewAllJobsLink(data);
             } else if (isValidPositionLocationTag) {
                 formatPositionLocation(data);
-                System.out.println();
             } else {
                 System.out.println(data);
             }
@@ -372,6 +393,8 @@ public class GreenhouseParse extends HTMLEditorKit.ParserCallback {
                 formatPTag(data);
             } else if (isValidSTRONGTag) {
                 formatSTRONGTag(data);
+            } else if (isValidATag) {
+                formatATag(data);
             }
         }
     }


### PR DESCRIPTION
**Before The PR (Pull Request):**
There was no proper "back end" support for the proper parsing of text encapsulated within `<a></a>` resulting in that text being parsed according to the rules related to the tag enveloping the `<a></a>`.

**After The PR (Pull Request):**
There is basic "back end" support for the proper parsing of text encapsulated within `<a></a>`, allowing customization of how those tags can be handled.

**Why Was This Changed?**
Due to some issues with formatting the parsed "Job Description", the addition of the ability to support `<a></a>` within the 'GreenhouseParse' class was made to avoid future issues with document parsing and formatting.

**What Was Changed?**
- Added class state for <a> tag parsing support.
- Added methods to handle <a> tags.
- Added new tag methods to `handle...Tag()`, `handleText()` methods.
- Removed a `System.out.println()`

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Closes #9 

**Mentions:** _(Type `@` then the person's name)_
N/A